### PR TITLE
fix: center code tour title icon

### DIFF
--- a/extension/github/add-code-tour.ts
+++ b/extension/github/add-code-tour.ts
@@ -38,6 +38,7 @@ function formatAndSanitizeDescription(rawText: string): string {
 
 function buildTitleRow(currentStep: EnhancedCodeTourStep, stepNumber: number) {
   const titleRow = document.createElement('p')
+  titleRow.setAttribute('style', 'display: flex; align-items: center;')
 
   const img = document.createElement('img')
   img.setAttribute('src', chrome.extension.getURL('code-tour.png'))


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/1114230/107072452-718ae880-67e6-11eb-9f9a-b09162bccdc0.png)

After
![image](https://user-images.githubusercontent.com/1114230/107072423-62a43600-67e6-11eb-8d9c-ed4dffb592ab.png)