### PR TITLE
Support multi selection

### DIFF
--- a/extension/github/__snapshots__/add-code-tour.test.ts.snap
+++ b/extension/github/__snapshots__/add-code-tour.test.ts.snap
@@ -118,6 +118,16 @@ exports[`buildTitleRow renders properly the code tour header 1`] = `
 </p>
 `;
 
+exports[`getParent fallbacks to step selection when step line is missing 1`] = `
+<div
+  class="blob-code"
+  id="LC20"
+>
+  
+      
+</div>
+`;
+
 exports[`getParent returns the line of the file for a file step 1`] = `
 <div
   class="blob-code"

--- a/extension/github/add-code-tour.test.ts
+++ b/extension/github/add-code-tour.test.ts
@@ -1,4 +1,4 @@
-import { buildSection, buildTitleRow, getParent } from './add-code-tour'
+import { buildSection, buildTitleRow, getParent, highlightRows } from './add-code-tour'
 
 global.chrome = {
   // @ts-expect-error mocking the chrome API in tests
@@ -19,6 +19,7 @@ describe(buildTitleRow, () => {
           previousUrl: 'the/next/url?with=params',
           tour: {
             title: 'The code tour title',
+            slang: 'Thecodetourtitle',
             step: 3,
             steps: [],
             ref: 'alongcommitid',
@@ -43,6 +44,7 @@ describe(buildSection, () => {
           previousUrl: 'the/next/url?with=params',
           tour: {
             title: 'The code tour title',
+            slang: 'Thecodetourtitle',
             step: 3,
             steps: [],
             ref: 'alongcommitid',
@@ -63,6 +65,7 @@ describe(buildSection, () => {
           file: '/package.json',
           tour: {
             title: 'The code tour title',
+            slang: 'Thecodetourtitle',
             step: 3,
             steps: [],
             ref: 'alongcommitid',
@@ -87,6 +90,7 @@ describe(getParent, () => {
         file: '/package.json',
         tour: {
           title: 'The code tour title',
+          slang: 'Thecodetourtitle',
           step: 3,
           steps: [],
           ref: 'alongcommitid',
@@ -106,6 +110,7 @@ describe(getParent, () => {
         directory: 'the directory',
         tour: {
           title: 'The code tour title',
+          slang: 'Thecodetourtitle',
           step: 3,
           steps: [],
           ref: 'alongcommitid',
@@ -113,5 +118,94 @@ describe(getParent, () => {
         },
       }),
     ).toMatchSnapshot()
+  })
+
+  it('fallbacks to step selection when step line is missing', () => {
+    document.body.innerHTML = `
+       <div id="LC20" class="blob-code" />
+      `
+
+    expect(
+      getParent({
+        description: 'code tour description',
+        line: undefined,
+        selection: {
+          start: {
+            line: 10,
+            character: 7,
+          },
+          end: { line: 20, character: 7 },
+        },
+        file: '/package.json',
+        tour: {
+          title: 'The code tour title',
+          slang: 'Thecodetourtitle',
+          step: 3,
+          steps: [],
+          ref: 'alongcommitid',
+          repository: 'doctolib/code-tours-github',
+        },
+      }),
+    ).toMatchSnapshot()
+  })
+})
+
+describe(highlightRows, () => {
+  it('renders multiple highlighted code rows', () => {
+    document.body.innerHTML = `
+       <div id="LC20" class="blob-code" />
+       <div id="LC21" class="blob-code" />
+       <div id="LC22" class="blob-code" />
+      `
+
+    highlightRows({
+      description: 'code tour description',
+      line: undefined,
+      selection: {
+        start: {
+          line: 20,
+          character: 7,
+        },
+        end: { line: 21, character: 7 },
+      },
+      file: '/package.json',
+      tour: {
+        title: 'The code tour title',
+        slang: 'Thecodetourtitle',
+        step: 3,
+        steps: [],
+        ref: 'alongcommitid',
+        repository: 'doctolib/code-tours-github',
+      },
+    })
+
+    expect(document.querySelector('#LC20')?.classList.contains('highlighted')).toBe(true)
+    expect(document.querySelector('#LC21')?.classList.contains('highlighted')).toBe(true)
+    expect(document.querySelector('#LC22')?.classList.contains('highlighted')).toBe(false)
+  })
+
+  it('renders one highlighted code row', () => {
+    document.body.innerHTML = `
+       <div id="LC20" class="blob-code" />
+       <div id="LC21" class="blob-code" />
+      `
+
+    highlightRows({
+      description: 'code tour description',
+      line: 21,
+      selection: undefined,
+      file: '/package.json',
+      tour: {
+        title: 'The code tour title',
+        slang: 'Thecodetourtitle',
+        step: 3,
+        steps: [],
+        ref: 'alongcommitid',
+        repository: 'doctolib/code-tours-github',
+      },
+    })
+
+    expect(document.querySelector('#LC20')?.classList.contains('highlighted')).toBe(false)
+    expect(document.querySelector('#LC21')?.classList.contains('highlighted')).toBe(true)
   })
 })

--- a/extension/github/add-code-tour.ts
+++ b/extension/github/add-code-tour.ts
@@ -24,10 +24,31 @@ function buttonTo(text: string, url?: string): Element {
   return button
 }
 
+function getCodeLineDOM(currentLine: number) {
+  return document.querySelector(`#LC${currentLine}.blob-code`)
+}
+
+export function highlightRows(step: EnhancedCodeTourStep): void {
+  if (!('file' in step)) return
+
+  const startLine = step.selection?.start.line ?? step.line
+  const endLine = step.selection?.end.line ?? step.line
+
+  if (startLine && endLine) {
+    for (let codeLine = startLine; codeLine <= endLine; codeLine += 1) {
+      const node = getCodeLineDOM(codeLine)
+      node?.classList.add('highlighted')
+    }
+  }
+}
+
 export function getParent(currentStep: EnhancedCodeTourStep): Element | null {
   if ('file' in currentStep) {
-    const currentLine = currentStep.line
-    return document.querySelector(`#LC${currentLine}.blob-code`)
+    const currentLine = currentStep.line ?? currentStep.selection?.end.line
+
+    if (currentLine) {
+      return getCodeLineDOM(currentLine)
+    }
   }
   return document.querySelector('div.repository-content')
 }
@@ -112,8 +133,9 @@ export async function addCodeTour(): Promise<void> {
   const parent = getParent(currentStep)
   if (!parent) return
   if ('file' in currentStep) {
+    highlightRows(currentStep)
+
     parent.append(section)
-    parent.classList.add('highlighted')
     parent.scrollIntoView({ behavior: 'auto', block: 'center' })
   } else {
     parent.prepend(section)

--- a/extension/types/code-tour.ts
+++ b/extension/types/code-tour.ts
@@ -1,7 +1,16 @@
+interface CodeTourStepPosition {
+  line: number
+  character: number
+}
+
 interface CodeTourFileStep {
   description: string
   file: string
-  line: number
+  line?: number
+  selection?: {
+    start: CodeTourStepPosition
+    end: CodeTourStepPosition
+  }
 }
 
 export interface CodeTourDirectoryStep {


### PR DESCRIPTION
The current tool doesn't work when the "lines" key is empty for a step configuration, causing the whole tour to be broken. 

There are many tours impacted by this bugs.
This is probably because "lines" are optional keys during the tour creation, so it's a good idea that our tool supports optional "lines" too.

This PR brings:
- a support for selection configuration so that we can highlight multilple lines during a step (like it's done on the VSCODE plugin)
- a fallback for selection configuration when "lines" key is missing

![image](https://user-images.githubusercontent.com/80260620/113674784-dd8cae80-96ba-11eb-90ae-ec8b15fde8f4.png)
